### PR TITLE
Add forking link to GitLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Template of [Crev Proof Repository](https://github.com/crev-dev/crev/wiki/Proof-Repository)
 
-[Fork](https://github.com/crev-dev/crev-proofs/fork) this repo to create your own, empty Proof Repository.
+[Fork this repo on GitHub](https://github.com/crev-dev/crev-proofs/fork) or [on GitLab](https://gitlab.com/crev-dev/crev-proofs/-/forks/new) to create your own, empty Proof Repository.


### PR DESCRIPTION
As both are usable references for a combined list of people-who-forked-the-repo-to-be-discoverable, mentioning both GitHub and GitLab forking point.

Alternatively, we could link to the respective forking point on each repo and make them not clones of each other, but I think that it's convenient to have a shared parent as people moving their IDs over from one hoster to another could then fork-and-push without using force.